### PR TITLE
Fix the bits argument of vssource.source()

### DIFF
--- a/vssource/funcs.py
+++ b/vssource/funcs.py
@@ -204,12 +204,12 @@ def source(
                     continue
 
                 try:
-                    clip = indexerr.source(filepath)
+                    clip = indexerr.source(filepath, bits=bits)
                     break
                 except Exception as e:
                     if 'bgr0 is not supported' in str(e):
                         try:
-                            clip = indexerr.source(filepath, format='rgb24')
+                            clip = indexerr.source(filepath, format='rgb24', bits=bits)
                             break
                         except Exception:
                             ...


### PR DESCRIPTION
The `.source()` function of the Indexer class will call `initialize_clip` on the loaded clip, which converts 8-bit colors to 16-bit by default.

This means that the bits argument of `vssource.source` must be forwarded to `Indexer.source`. Otherwise, loading an 8-bit source with `bits=8` would needlessly convert the colors to 16-bit and back.

Similarly, using `bits=-1` to load a source in its native bit depth would always return a 16-bit clip for an 8-bit source.